### PR TITLE
Asset price USD endpoint

### DIFF
--- a/src/constants/tickers.ts
+++ b/src/constants/tickers.ts
@@ -9751,4 +9751,27 @@ export const tickers = [
       ethereum: '0x6fa5e1c43b5a466cbd1cae7993b67c982400d481',
     },
   },
+  {
+    coingeckoId: 'wrapped-steth',
+    icon: 'https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1696518295',
+    ticker: 'WSTETH',
+    name: 'Wrapped stETH',
+    platforms: {
+      ethereum: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0',
+      'polygon-pos': '0x03b54a6e9a984069379fae1a4fc4dbae93b3bccd',
+      'arbitrum-one': '0x5979d7b546e38e414f7e9822514be443a4800529',
+      'optimistic-ethereum': '0x1f32b1c2345538c0c6f582fcb022739c4a194ebb',
+    },
+  },
+  {
+    coingeckoId: 'thorstarter',
+    icon: 'https://assets.coingecko.com/coins/images/16835/large/thorstarter.jpg?1696516403',
+    ticker: 'XRUNE',
+    name: 'Thorstarter',
+    platforms: {
+      ethereum: '0x69fa0fee221ad11012bab0fdb45d444d3d2ce71c',
+      terra: 'terra1td743l5k5cmfy7tqq202g7vkmdvq35q48u2jfm',
+      fantom: '0xe1e6b01ae86ad82b1f1b4eb413b219ac32e17bf6',
+    },
+  },
 ]

--- a/src/modules/balance/balance.service.ts
+++ b/src/modules/balance/balance.service.ts
@@ -5,7 +5,7 @@ import { BalancesResponse } from '@covalenthq/client-sdk'
 import { BncClient } from '@binance-chain/javascript-sdk/lib/client'
 import BigNumber from 'bignumber.js'
 import axios from 'axios'
-import { Balance, BalanceResponse, BnbBalance } from './types/balance'
+import { Balance, BalanceResponse, BnbBalance } from './types'
 import { assetAmount, assetFromString, assetToBase, baseAmount } from '@xchainjs/xchain-util'
 import {
   BCH_DECIMAL,
@@ -374,7 +374,7 @@ export class BalanceService {
       })
     }
     const usdPrices = await this.priceService.fetchPricesFromCoingecko(
-      rawBalances.map((balance) => assetFromString(`BNB.${balance.symbol}`)),
+      rawBalances.map((balance) => assetFromString(`BNB.${balance.symbol}`).ticker),
     )
     let totalBalanceInUsd = new BigNumber(0)
     const balances = rawBalances.map((balance) => {
@@ -487,7 +487,7 @@ export class BalanceService {
       balances.push({ denom: 'uatom', amount: '0' } as unknown as proto.cosmos.base.v1beta1.Coin)
     }
     const assetPrices = await this.priceService.fetchPricesFromCoingecko(
-      balances.map((balance) => getCosmosAssetFromDenom(balance.denom)),
+      balances.map((balance) => getCosmosAssetFromDenom(balance.denom).ticker),
     )
     let totalBalanceInUsd = new BigNumber(0)
     const assets = balances
@@ -602,7 +602,9 @@ export class BalanceService {
       })
     })
 
-    const usdPrices = await this.priceService.fetchPricesFromCoingecko(mappedBalances.map((balance) => balance.asset))
+    const usdPrices = await this.priceService.fetchPricesFromCoingecko(
+      mappedBalances.map((balance) => balance.asset.ticker),
+    )
 
     const apiBalances = mappedBalances.map((t) => {
       const assetPrice = usdPrices[t.asset.ticker].toString() || '0'

--- a/src/modules/price/price.controller.ts
+++ b/src/modules/price/price.controller.ts
@@ -2,7 +2,7 @@ import { CACHE_MANAGER } from '@nestjs/cache-manager'
 import { Controller, Get, Inject, Param } from '@nestjs/common'
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger'
 import { PriceService } from './price.service'
-import { PriceHistoryResponse } from './types'
+import { PriceHistoryResponse, PriceUSDResponse } from './types'
 import { Cache } from 'cache-manager'
 import { PRICE_CACHE } from './cache-keys/price.cache-keys'
 import { CACHE_TIME } from '../../constants'
@@ -32,5 +32,14 @@ export class PriceController {
     this.cacheManager.set(PRICE_CACHE.coingeckoHistory(ticker, 7), history, CACHE_TIME.hour * 24)
 
     return history
+  }
+
+  @Get('/usd/:ticker')
+  @ApiOperation({
+    summary: 'Get price in usd for a given ticker',
+  })
+  @ApiResponse({ status: 200, description: 'Success', type: PriceUSDResponse })
+  async getUsdPrice(@Param('ticker') ticker: string): Promise<Record<string, number>> {
+    return this.priceService.fetchPricesFromCoingecko([ticker])
   }
 }

--- a/src/modules/price/price.service.ts
+++ b/src/modules/price/price.service.ts
@@ -1,6 +1,5 @@
 import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
-import { Asset } from '@xchainjs/xchain-util'
 import axios from 'axios'
 import { CACHE_TIME, tickers } from '../../constants'
 import { CACHE_MANAGER } from '@nestjs/cache-manager'
@@ -37,8 +36,8 @@ export class PriceService {
     return coingeckoId.toUpperCase()
   }
 
-  fetchPricesFromCoingecko = async (assets: Asset[]): Promise<Record<string, number>> => {
-    const mappedTickers = assets.map(({ ticker }) => this.mapTickerToCoinGeckoId(ticker)).join(',')
+  fetchPricesFromCoingecko = async (tickers: string[]): Promise<Record<string, number>> => {
+    const mappedTickers = tickers.map((ticker) => this.mapTickerToCoinGeckoId(ticker)).join(',')
 
     const cachedData = await this.cacheManager.get<Record<string, number>>(PRICE_CACHE.coingeckoAssets(mappedTickers))
     if (cachedData) {

--- a/src/modules/price/types/price.types.ts
+++ b/src/modules/price/types/price.types.ts
@@ -23,3 +23,8 @@ export class PriceHistoryResponse {
   @ApiProperty({ description: 'Source of the price history', enum: PriceHistoryResponse, required: false })
   source: PriceHistorySource
 }
+
+export class PriceUSDResponse {
+  @ApiProperty({ description: 'Asset price in USD' })
+  priceUSD: number
+}


### PR DESCRIPTION
Implemented separate price USD endpoint. 
Existing price/history/:ticker endpoint makes 2 calls to coingecko API in order to collect all data. 
Send feature at front-end requires show asset price at the top after user selected asset. We can't use priceUsd property from user balances here as user can select asset he doesn't have (he is able to select not to send). And this endpoint will be useful for swap feature in future.

Also added 2 missing assets data to src/contracts/tickers.ts
